### PR TITLE
[PERF-297] Improve handling when there are no LEA's in the API

### DIFF
--- a/src/edfi-performance-test/edfi_performance_test/api/client/education.py
+++ b/src/edfi-performance-test/edfi_performance_test/api/client/education.py
@@ -5,6 +5,8 @@
 
 from typing import Dict
 
+from edfi_performance_test.helpers.perf_suite_error import PerfSuiteError
+
 from edfi_performance_test.api.client.ed_fi_api_client import (
     EdFiAPIClient,
     import_from_dotted_path,
@@ -122,7 +124,13 @@ class LocalEducationAgencyClient(EdFiAPIClient):
             "edfi_performance_test.api.client.education.LocalEducationAgencyClient"
         )
         client_instance = client_class(client_class.client, token=client_class.token)
-        cls._education_organization_id = client_instance.get_list()[0][
+
+        ed_orgs = client_instance.get_list()
+
+        if ed_orgs is None or len(ed_orgs) == 0:
+            raise PerfSuiteError("There no local education agencies. Please create one and then try this test again.")
+
+        cls._education_organization_id = ed_orgs[0][
             "localEducationAgencyId"
         ]
         return cls._education_organization_id

--- a/src/edfi-performance-test/edfi_performance_test/helpers/perf_suite_error.py
+++ b/src/edfi-performance-test/edfi_performance_test/helpers/perf_suite_error.py
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: Apache-2.0
+# Licensed to the Ed-Fi Alliance under one or more agreements.
+# The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+# See the LICENSE and NOTICES files in the project root for more information.
+
+
+class PerfSuiteError(Exception):
+    """
+    An error object allowing us to raise an exception without using one of the
+    base classes.
+    """
+    pass


### PR DESCRIPTION
The new error message does not cause the system to stop the test, which surprised me. But it is still an improvement on the old error, because at least there is now a clear explanation in the log, as seen below.

![image](https://github.com/Ed-Fi-Exchange-OSS/Suite-3-Performance-Testing/assets/9324390/eb679273-485c-438b-9cb5-7e7d65513b7d)
