### PR TITLE
[PERF-300] Error running jupyter notebook from TC

### DIFF
--- a/eng/AzureTestLab.ps1
+++ b/eng/AzureTestLab.ps1
@@ -242,9 +242,7 @@ function Invoke-TestRunnerFromTeamCity($testType) {
         $zipReportPath
     }
 
-    # jupyter notebook with nbconvert build generates an unspecified error, however the report is generated
-    # ticket PERF-300 was created to review the case
-    $ErrorActionPreference = 'SilentlyContinue'
+
     Invoke-Command -Session $session -ArgumentList @($testType) {
         param($testType)
         C:\Users\edFiAdmin\run-deployed-tests.bat $testType $testResultsPath

--- a/eng/AzureTestLab.ps1
+++ b/eng/AzureTestLab.ps1
@@ -243,11 +243,10 @@ function Invoke-TestRunnerFromTeamCity($testType) {
     }
 
 
-    Invoke-Command -Session $session -ArgumentList @($testType) {
-        param($testType)
+    Invoke-Command -Session $session -ArgumentList @($testType, $testResultsPath) {
         C:\Users\edFiAdmin\run-deployed-tests.bat $testType $testResultsPath
 
-        $latest = Get-ChildItem $testResultsPath | ? { $_.PSIsContainer } | sort CreationTime -desc | select -f 1
+        $latest = Get-ChildItem $testResultsPath | Where-Object { $_.PSIsContainer } | Sort-Object CreationTime -desc | Select-Object -f 1
         $testResultsPath = Join-Path $testResultsPath $latest
 
         Add-Type -Assembly System.IO.Compression.FileSystem

--- a/run-report.bat
+++ b/run-report.bat
@@ -7,4 +7,4 @@ REM Write path to test results folder for notebook to process.
 echo %2>notebook_input.txt
 
 REM Launch the notebook run.
-powershell -NoProfile -ExecutionPolicy Bypass -Command "poetry run jupyter nbconvert --output-dir='.\..\..\' --to html --execute '%1 Test Analysis.ipynb' --no-input"
+powershell -NoProfile -ExecutionPolicy Bypass -Command "poetry run jupyter nbconvert --output-dir='.\..\..\' --to html --execute '%1 Test Analysis.ipynb' --no-input" 2> $null


### PR DESCRIPTION
Because EXE and BAT files write to stderr even when there is no error,  removed $ErrorActionPreference = 'SilentlyContinue' from Azure Test Lab and added in the bat that runs the report to set stderr to null