### PR TITLE
[PERF-259] Improve error handling when metadata disabled

### DIFF
--- a/src/edfi-paging-test/edfi_paging_test/helpers/api_metadata.py
+++ b/src/edfi-paging-test/edfi_paging_test/helpers/api_metadata.py
@@ -36,8 +36,8 @@ def get_base_api_response(api_base_url: str, verify_cert: bool = True) -> Dict[s
             api_base_url,
             verify=verify_cert
             ).json()
-    except Exception as e:
-        raise RuntimeError(f"Error fetching: {api_base_url}") from e
+    except requests.exceptions.RequestException as e:
+        raise RuntimeError(f"Error: {e}.") from e
 
 
 @cache

--- a/src/edfi-paging-test/edfi_paging_test/performance_tester.py
+++ b/src/edfi-paging-test/edfi_paging_test/performance_tester.py
@@ -59,7 +59,7 @@ def fetch_resource(request_client: RequestClient, target_resource: str) -> None:
 def invalid_resources(
     openapi_resources: List[str], resources_to_check: List[str]
 ) -> List[str]:
-    return [r for r in resources_to_check if r.lower() not in openapi_resources]
+    return [r for r in resources_to_check if r not in openapi_resources]
 
 
 async def run(args: MainArguments) -> None:

--- a/src/edfi-paging-test/edfi_paging_test/reporter/reporter.py
+++ b/src/edfi-paging-test/edfi_paging_test/reporter/reporter.py
@@ -44,7 +44,7 @@ def _calculate_statistics(df: DataFrame) -> DataFrame:
                 "MeanTime": s["MeanTime"].mean(),
                 # "Unbiased" estimate of standard deviation for a sample
                 # (ddof=1, panda's default). Equivalent of Excel STDEV.S()
-                "StDeviation": s["StDeviation"].std().round(6),
+                "StDeviation": s["StDeviation"].std().round(6),  # type: ignore
                 "NumberOfErrors": s[(s["StatusCode"] >= 400)]["StatusCode"].count(),
             }
         )

--- a/src/edfi-paging-test/edfi_paging_test/reporter/summary.py
+++ b/src/edfi-paging-test/edfi_paging_test/reporter/summary.py
@@ -20,8 +20,8 @@ class Summary:
     def __post_init__(self):
         if (self.run_configration):
             self.run_configration.resourceList = (self.run_configration.resourceList or ["all"])
-            self.run_configration.contentType = self.run_configration.contentType
-            self.run_configration.log_level = self.run_configration.log_level
+            self.run_configration.contentType = self.run_configration.contentType.value  # type: ignore
+            self.run_configration.log_level = self.run_configration.log_level.value  # type: ignore
 
     def get_DataFrame(self) -> DataFrame:
         """

--- a/src/edfi-paging-test/edfi_paging_test/reporter/summary.py
+++ b/src/edfi-paging-test/edfi_paging_test/reporter/summary.py
@@ -18,10 +18,10 @@ class Summary:
     machine_name : str = socket.gethostname()
 
     def __post_init__(self):
-        if(self.run_configration):
+        if (self.run_configration):
             self.run_configration.resourceList = (self.run_configration.resourceList or ["all"])
-            self.run_configration.contentType = self.run_configration.contentType.value
-            self.run_configration.log_level = self.run_configration.log_level.value
+            self.run_configration.contentType = self.run_configration.contentType
+            self.run_configration.log_level = self.run_configration.log_level
 
     def get_DataFrame(self) -> DataFrame:
         """

--- a/src/edfi-paging-test/tests/reporter/test_reporter.py
+++ b/src/edfi-paging-test/tests/reporter/test_reporter.py
@@ -1,5 +1,5 @@
 import pytest
-import re
+# import re
 from pandas import DataFrame, read_csv, read_json
 from os import path
 from edfi_paging_test.reporter.summary import Summary
@@ -474,4 +474,5 @@ def describe_when_creating_summary_json() -> None:
             with open(EXPECTED_FILE) as f:
                 actual = f.read()
 
-                assert actual == re.sub('\\s+', '', CONTENTS)
+                # assert actual == re.sub('\\s+', '', CONTENTS)
+                assert actual == CONTENTS

--- a/src/edfi-paging-test/tests/reporter/test_reporter.py
+++ b/src/edfi-paging-test/tests/reporter/test_reporter.py
@@ -1,5 +1,5 @@
 import pytest
-# import re
+import re
 from pandas import DataFrame, read_csv, read_json
 from os import path
 from edfi_paging_test.reporter.summary import Summary
@@ -474,5 +474,4 @@ def describe_when_creating_summary_json() -> None:
             with open(EXPECTED_FILE) as f:
                 actual = f.read()
 
-                # assert actual == re.sub('\\s+', '', CONTENTS)
-                assert actual == CONTENTS
+                assert actual == re.sub('\\s+', '', CONTENTS)


### PR DESCRIPTION
- Return the error detail that occurs when the API URL cannot be accessed.

- Removed lowercase comparison that generated an error when using the PERF_RESOURCE_LIST environment variable

- Fixed errors when opening each .py file # type: ignore

- Bug fixes reported by flake8