### PR TITLE
[PERF-339] Performance test fixes for DS 5 and DMS

### DIFF
--- a/docs/how-to-create-tests.md
+++ b/docs/how-to-create-tests.md
@@ -54,7 +54,7 @@ Perform the following steps to create a factory (let's call our example resource
        numberOfParts = 1
        identificationCodes = factory.LazyAttribute(
             lambda o: build_descriptor_dicts(
-                "courseIdentificationSystem",
+                "CourseIdentificationSystem",
                 [("State course code", {"identificationCode": o.courseCode})],
             )
         )
@@ -243,8 +243,8 @@ Perform the following steps to create a simple volume test:
               "levelCharacteristics",
               [
                 {
-                    "courseLevelCharacteristicDescriptor": build_descriptor(
-                        "courseLevelCharacteristic", "Basic"
+                    "CourseLevelCharacteristicDescriptor": build_descriptor(
+                        "CourseLevelCharacteristic", "Basic"
                     )
                 }
               ],
@@ -284,8 +284,8 @@ Perform the following steps to create a simple volume test:
               "levelCharacteristics",
               [
                 {
-                    "courseLevelCharacteristicDescriptor": build_descriptor(
-                        "courseLevelCharacteristic", "Basic"
+                    "CourseLevelCharacteristicDescriptor": build_descriptor(
+                        "CourseLevelCharacteristic", "Basic"
                     )
                 }
               ],

--- a/src/edfi-performance-test/edfi_performance_test/api/client/course_offering.py
+++ b/src/edfi-performance-test/edfi_performance_test/api/client/course_offering.py
@@ -16,6 +16,7 @@ class CourseOfferingClient(EdFiAPIClient):
     def create_with_dependencies(self, **kwargs):
         school_id = kwargs.pop("schoolId", SchoolClient.shared_elementary_school_id())
         school_year = kwargs.get("schoolYear", 2014)
+        course_code = kwargs.pop("courseCode", "ELA-01")
         session_reference = self.session_client.create_with_dependencies(
             schoolId=school_id, schoolYear=school_year
         )
@@ -27,5 +28,7 @@ class CourseOfferingClient(EdFiAPIClient):
             sessionReference__sessionName=session_reference["attributes"][
                 "sessionName"
             ],
+            courseReference_courseCode=course_code,
+            courseReference_educationOrganizationId=school_id,
             **kwargs
         )

--- a/src/edfi-performance-test/edfi_performance_test/api/client/ed_fi_api_client.py
+++ b/src/edfi-performance-test/edfi_performance_test/api/client/ed_fi_api_client.py
@@ -142,6 +142,9 @@ class EdFiAPIClient(EdFiBasicAPIClient):
             response.failure("Status code {} is a failure".format(response.status_code))
             return
         if self.is_not_expected_result(response, [200, 201]):
+            logger.error(
+                f"{response.request.method} {response.request.url} - REQUEST BODY: {payload}"
+            )
             if unique_id is not None:
                 return None, None
             return None
@@ -153,6 +156,8 @@ class EdFiAPIClient(EdFiBasicAPIClient):
 
     def update(self, resource_id, **update_kwargs):
         # Be sure to pass in a fully defined object; ODS doesn't allow partial updates.
+        # Include resource_id in the payload; DMS currently requires it.
+        update_kwargs['id'] = resource_id
         payload = self.factory.build_json(**update_kwargs)
         response = self._get_response(
             "put",

--- a/src/edfi-performance-test/edfi_performance_test/api/client/grade.py
+++ b/src/edfi-performance-test/edfi_performance_test/api/client/grade.py
@@ -35,10 +35,11 @@ class GradeClient(EdFiAPIClient):
             assoc_reference,
             gradingPeriodReference__schoolId=school_id,
             gradingPeriodReference__periodSequence=grade_period["periodSequence"],
+            gradingPeriodReference__gradingPeriodName=grade_period["gradingPeriodName"],
+            gradingPeriodReference__schoolYear=section_reference["schoolYear"],
             gradingPeriodReference__gradingPeriodDescriptor=grade_period[
                 "gradingPeriodDescriptor"
             ],
-            gradingPeriodReference__schoolYear=section_reference["schoolYear"],
             studentSectionAssociationReference__sectionIdentifier=section_reference[
                 "sectionIdentifier"
             ],

--- a/src/edfi-performance-test/edfi_performance_test/api/client/report_card.py
+++ b/src/edfi-performance-test/edfi_performance_test/api/client/report_card.py
@@ -26,5 +26,14 @@ class ReportCardClient(EdFiAPIClient):
             gradingPeriodReference__periodSequence=period_reference["attributes"][
                 "periodSequence"
             ],
+            gradingPeriodReference__gradingPeriodName=period_reference["attributes"][
+                "gradingPeriodName"
+            ],
+            gradingPeriodReference__schoolId=period_reference["attributes"][
+                "schoolReference"][
+                "schoolId"],
+            gradingPeriodReference__schoolYear=period_reference["attributes"][
+                "schoolYearTypeReference"][
+                "schoolYear"],
             studentReference__studentUniqueId=studentUniqueId,
         )

--- a/src/edfi-performance-test/edfi_performance_test/api/client/school.py
+++ b/src/edfi-performance-test/edfi_performance_test/api/client/school.py
@@ -27,6 +27,7 @@ class SchoolClient(EdFiAPIClient):
                     return cls._high_school_id
                 cls._high_school_id = cls.create_shared_resource("schoolId")
                 cls._create_school_course_code(cls._high_school_id, "ALG-2")
+                cls._create_school_course_code(cls._high_school_id, "ELA-01")
                 cls._create_school_graduation_plan(cls._high_school_id, 2020)
             return cls._high_school_id
 

--- a/src/edfi-performance-test/edfi_performance_test/api/client/section.py
+++ b/src/edfi-performance-test/edfi_performance_test/api/client/section.py
@@ -55,6 +55,7 @@ class SectionClient(EdFiAPIClient):
             ][
                 "classPeriodName"
             ],
+            classPeriods__0__classPeriodReference__schoolId=school_id,
             courseOfferingReference__localCourseCode=course_offering_attrs[
                 "localCourseCode"
             ],

--- a/src/edfi-performance-test/edfi_performance_test/api/client/session.py
+++ b/src/edfi-performance-test/edfi_performance_test/api/client/session.py
@@ -52,6 +52,30 @@ class SessionClient(EdFiAPIClient):
             ][
                 "periodSequence"
             ],
+            gradingPeriods__0__gradingPeriodReference__gradingPeriodDescriptor=period_1_reference[
+                "attributes"
+            ][
+                "gradingPeriodDescriptor"
+            ],
+            gradingPeriods__1__gradingPeriodReference__gradingPeriodDescriptor=period_2_reference[
+                "attributes"
+            ][
+                "gradingPeriodDescriptor"
+            ],
+            gradingPeriods__0__gradingPeriodReference__gradingPeriodName=period_1_reference[
+                "attributes"
+            ][
+                "gradingPeriodName"
+            ],
+            gradingPeriods__1__gradingPeriodReference__gradingPeriodName=period_2_reference[
+                "attributes"
+            ][
+                "gradingPeriodName"
+            ],
+            gradingPeriods__0__gradingPeriodReference__schoolId=school_id,
+            gradingPeriods__1__gradingPeriodReference__schoolId=school_id,
+            gradingPeriods__0__gradingPeriodReference__schoolYear=school_year,
+            gradingPeriods__1__gradingPeriodReference__schoolYear=school_year,
             **kwargs
         )
 

--- a/src/edfi-performance-test/edfi_performance_test/api/client/student.py
+++ b/src/edfi-performance-test/edfi_performance_test/api/client/student.py
@@ -478,6 +478,15 @@ class StudentCompetencyObjectiveClient(EdFiAPIClient):
             gradingPeriodReference__periodSequence=period_reference["attributes"][
                 "periodSequence"
             ],
+            gradingPeriodReference__gradingPeriodName=period_reference["attributes"][
+                "gradingPeriodName"
+            ],
+            gradingPeriodReference__schoolId=period_reference["attributes"][
+                "schoolReference"][
+                "schoolId"],
+            gradingPeriodReference__schoolYear=period_reference["attributes"][
+                "schoolYearTypeReference"][
+                "schoolYear"],
             objectiveCompetencyObjectiveReference__objective=objective_reference[
                 "attributes"
             ]["objective"],
@@ -696,6 +705,16 @@ class StudentLearningObjectiveClient(EdFiAPIClient):
             gradingPeriodReference__periodSequence=period_reference["attributes"][
                 "periodSequence"
             ],
+            gradingPeriodReference__gradingPeriodName=period_reference["attributes"][
+                "gradingPeriodName"
+            ],
+            gradingPeriodReference__schoolId=period_reference["attributes"][
+                "schoolReference"][
+                "schoolId"],
+            gradingPeriodReference__schoolYear=period_reference["attributes"][
+                "schoolYearTypeReference"][
+                "schoolYear"],
+
             studentReference__studentUniqueId=studentUniqueId,
             **kwargs
         )

--- a/src/edfi-performance-test/edfi_performance_test/factories/resources/bell_schedule.py
+++ b/src/edfi-performance-test/edfi_performance_test/factories/resources/bell_schedule.py
@@ -19,7 +19,7 @@ class BellScheduleFactory(APIFactory):
         [
             factory.Dict(
                 dict(
-                    classPeriodReference=factory.Dict(dict(classPeriodName=None)),
+                    classPeriodReference=factory.Dict(dict(classPeriodName=None, schoolId=SchoolClient.shared_elementary_school_id())),
                 )
             ),
         ]

--- a/src/edfi-performance-test/edfi_performance_test/factories/resources/calendar.py
+++ b/src/edfi-performance-test/edfi_performance_test/factories/resources/calendar.py
@@ -9,19 +9,18 @@ from edfi_performance_test.api.client.school import SchoolClient
 from edfi_performance_test.factories.resources.api_factory import APIFactory
 from edfi_performance_test.factories.descriptors.utils import build_descriptor
 from edfi_performance_test.factories.utils import (
-    RandomSuffixAttribute,
-    RandomSchoolYearAttribute,
+    UniqueIdAttribute,
 )
 
 
 class CalendarFactory(APIFactory):
     schoolYearTypeReference = factory.Dict(
         {
-            "schoolYear": RandomSchoolYearAttribute(),
+            "schoolYear": 2014,
         }
     )
     calendarTypeDescriptor = build_descriptor("CalendarType", "IEP")
-    calendarCode = RandomSuffixAttribute("107SS111111")
+    calendarCode = UniqueIdAttribute()
     schoolReference = factory.Dict(
         {"schoolId": SchoolClient.shared_elementary_school_id()}
     )

--- a/src/edfi-performance-test/edfi_performance_test/factories/resources/calendar_date.py
+++ b/src/edfi-performance-test/edfi_performance_test/factories/resources/calendar_date.py
@@ -16,7 +16,7 @@ from edfi_performance_test.factories.descriptors.utils import build_descriptor_d
 class CalendarDateFactory(APIFactory):
     calendarReference = factory.Dict(
         dict(
-            calendarCode="107SS111111",
+            calendarCode=None,  # Must be entered by client
             schoolId=SchoolClient.shared_elementary_school_id(),
             schoolYear=2014,
         )

--- a/src/edfi-performance-test/edfi_performance_test/factories/resources/course.py
+++ b/src/edfi-performance-test/edfi_performance_test/factories/resources/course.py
@@ -27,7 +27,7 @@ class CourseFactory(APIFactory):
     numberOfParts = 1
     identificationCodes = factory.LazyAttribute(
         lambda o: build_descriptor_dicts(
-            "courseIdentificationSystem",
+            "CourseIdentificationSystem",
             [("State course code", {"identificationCode": o.courseCode})],
         )
     )
@@ -36,7 +36,7 @@ class CourseFactory(APIFactory):
             factory.Dict(
                 dict(
                     courseLevelCharacteristicDescriptor=build_descriptor(
-                        "courseLevelCharacteristic", "Core Subject"
+                        "CourseLevelCharacteristic", "Core Subject"
                     )
                 )
             ),

--- a/src/edfi-performance-test/edfi_performance_test/factories/resources/grade.py
+++ b/src/edfi-performance-test/edfi_performance_test/factories/resources/grade.py
@@ -22,6 +22,7 @@ class GradeFactory(APIFactory):
                 "GradingPeriod", "First Six Weeks"
             ),
             periodSequence=1,
+            gradingPeriodName=None,
             schoolYear=current_year(),
         )
     )

--- a/src/edfi-performance-test/edfi_performance_test/factories/resources/grading_period.py
+++ b/src/edfi-performance-test/edfi_performance_test/factories/resources/grading_period.py
@@ -8,11 +8,12 @@ import factory
 from edfi_performance_test.api.client.school import SchoolClient
 from edfi_performance_test.factories.resources.api_factory import APIFactory
 from edfi_performance_test.factories.descriptors.utils import build_descriptor
-from edfi_performance_test.factories.utils import UniquePrimaryKeyAttribute
+from edfi_performance_test.factories.utils import UniquePrimaryKeyAttribute, UniqueIdAttribute
 
 
 class GradingPeriodFactory(APIFactory):
     periodSequence = UniquePrimaryKeyAttribute()
+    gradingPeriodName = UniqueIdAttribute()
     beginDate = "2014-08-23"
     endDate = "2014-10-04"
     totalInstructionalDays = 29

--- a/src/edfi-performance-test/edfi_performance_test/factories/resources/graduation_plan.py
+++ b/src/edfi-performance-test/edfi_performance_test/factories/resources/graduation_plan.py
@@ -14,7 +14,7 @@ class GraduationPlanFactory(APIFactory):
     totalRequiredCredits = 28
     graduationPlanTypeDescriptor = build_descriptor(
         "GraduationPlanType",
-        random.choice(["Recommended", "Distinguished", "Minimum", "Standard"]),
+        random.choice(["Recommended", "Distinguished", "Minimum", "Standard", "Career and Technical Education"]),
     )
     educationOrganizationReference = factory.Dict(
         dict(educationOrganizationId=None),

--- a/src/edfi-performance-test/edfi_performance_test/factories/resources/report_card.py
+++ b/src/edfi-performance-test/edfi_performance_test/factories/resources/report_card.py
@@ -23,6 +23,7 @@ class ReportCardFactory(APIFactory):
     gradingPeriodReference = factory.Dict(
         dict(
             periodSequence=None,  # Must be created
+            gradingPeriodName=None,  # Must be created
             schoolId=SchoolClient.shared_elementary_school_id(),
             schoolYear=2014,
             gradingPeriodDescriptor=build_descriptor(

--- a/src/edfi-performance-test/edfi_performance_test/factories/resources/section.py
+++ b/src/edfi-performance-test/edfi_performance_test/factories/resources/section.py
@@ -23,7 +23,7 @@ class SectionFactory(APIFactory):
             factory.Dict(
                 dict(
                     classPeriodReference=factory.Dict(
-                        dict(classPeriodName=None)  # Must be entered by client
+                        dict(classPeriodName=None, schoolId=SchoolClient.shared_elementary_school_id()),  # Must be entered by client
                     ),
                 ),
             ),

--- a/src/edfi-performance-test/edfi_performance_test/factories/resources/session.py
+++ b/src/edfi-performance-test/edfi_performance_test/factories/resources/session.py
@@ -27,6 +27,9 @@ class SessionFactory(APIFactory):
                                 "GradingPeriod", "First Six Weeks"
                             ),
                             periodSequence=None,  # Must be entered by client
+                            gradingPeriodName=None,  # Must be entered by client
+                            schoolId=SchoolClient.shared_elementary_school_id(),
+                            schoolYear=2014,
                         )
                     ),
                 ),
@@ -39,6 +42,9 @@ class SessionFactory(APIFactory):
                                 "GradingPeriod", "Second Six Weeks"
                             ),
                             periodSequence=None,  # Must be entered by client
+                            gradingPeriodName=None,  # Must be entered by client
+                            schoolId=SchoolClient.shared_elementary_school_id(),
+                            schoolYear=2014,
                         )
                     ),
                 ),

--- a/src/edfi-performance-test/edfi_performance_test/factories/resources/staff.py
+++ b/src/edfi-performance-test/edfi_performance_test/factories/resources/staff.py
@@ -73,7 +73,7 @@ class StaffFactory(APIFactory):
     )
     identificationCodes = factory.LazyAttribute(
         lambda o: build_descriptor_dicts(
-            "staffIdentificationSystem",
+            "StaffIdentificationSystem",
             [("State", {"identificationCode": o.staffUniqueId})],
         )
     )

--- a/src/edfi-performance-test/edfi_performance_test/factories/resources/student.py
+++ b/src/edfi-performance-test/edfi_performance_test/factories/resources/student.py
@@ -148,7 +148,7 @@ class StudentEducationOrganizationAssociationFactory(APIFactory):
         [
             dict(
                 indicatorName="At Risk",
-                indicator=True,
+                indicator="True",
             ),
         ]
     )
@@ -330,6 +330,7 @@ class StudentCompetencyObjectiveFactory(APIFactory):
             schoolId=SchoolClient.shared_elementary_school_id(),  # Prepopulated school
             schoolYear=2014,  # Prepopulated schoolYear
             periodSequence=None,  # Must be entered by the user
+            gradingPeriodName=None,  # Must be entered by the user
             gradingPeriodDescriptor=build_descriptor(
                 "GradingPeriod", "First Six Weeks"
             ),
@@ -483,6 +484,7 @@ class StudentLearningObjectiveFactory(APIFactory):
                 "GradingPeriod", "First Six Weeks"
             ),
             periodSequence=None,  # Must be entered by user
+            gradingPeriodName=None,  # Must be entered by user
             schoolId=SchoolClient.shared_elementary_school_id(),
             schoolYear=2014,
         )

--- a/src/edfi-performance-test/edfi_performance_test/factories/resources/v5/student.py
+++ b/src/edfi-performance-test/edfi_performance_test/factories/resources/v5/student.py
@@ -57,4 +57,4 @@ class StudentSpecialEducationProgramEligibilityAssociationFactory(APIFactory):
         dict(studentUniqueId=111111)
     )
     evaluationCompleteIndicator = False
-    ideaPartDescriptor = build_descriptor("IdeaPart", "IDEA Part B")
+    ideaPartDescriptor = build_descriptor("IDEAPart", "IDEA Part B")

--- a/src/edfi-performance-test/edfi_performance_test/factories/utils.py
+++ b/src/edfi-performance-test/edfi_performance_test/factories/utils.py
@@ -84,11 +84,11 @@ class RandomDateAttribute(declarations.BaseDeclaration):
 
 class RandomSchoolYearAttribute(declarations.BaseDeclaration):
     """
-    Returns a random date between 1991 & 2050.
+    Returns a random date between 1991 & 2026.
     """
 
     def evaluate(self, instance, step, extra):
-        return random.randint(1991, 2050)
+        return random.randint(1991, 2026)
 
 
 class RandomSuffixAttribute(LazyAttribute):

--- a/src/edfi-performance-test/edfi_performance_test/factories/utils.py
+++ b/src/edfi-performance-test/edfi_performance_test/factories/utils.py
@@ -84,11 +84,11 @@ class RandomDateAttribute(declarations.BaseDeclaration):
 
 class RandomSchoolYearAttribute(declarations.BaseDeclaration):
     """
-    Returns a random date between 1991 & 2026.
+    Returns a random date between 1991 & 2037.
     """
 
     def evaluate(self, instance, step, extra):
-        return random.randint(1991, 2026)
+        return random.randint(1991, 2037)
 
 
 class RandomSuffixAttribute(LazyAttribute):

--- a/src/edfi-performance-test/edfi_performance_test/tasks/pipeclean/student.py
+++ b/src/edfi-performance-test/edfi_performance_test/tasks/pipeclean/student.py
@@ -153,4 +153,4 @@ class StudentSchoolFoodServiceProgramAssociationPipecleanTest(EdFiPipecleanTestB
 
 class StudentAssessmentPipecleanTest(EdFiPipecleanTestBase):
     update_attribute_name = "serialNumber"
-    update_attribute_value = 2
+    update_attribute_value = "2"

--- a/src/edfi-performance-test/edfi_performance_test/tasks/volume/course.py
+++ b/src/edfi-performance-test/edfi_performance_test/tasks/volume/course.py
@@ -20,7 +20,7 @@ class CourseVolumeTest(EdFiVolumeTestBase):
             [
                 {
                     "courseLevelCharacteristicDescriptor": build_descriptor(
-                        "courseLevelCharacteristic", "Basic"
+                        "CourseLevelCharacteristic", "Basic"
                     )
                 }
             ],

--- a/src/edfi-performance-test/edfi_performance_test/tasks/volume/course_offering.py
+++ b/src/edfi-performance-test/edfi_performance_test/tasks/volume/course_offering.py
@@ -5,22 +5,10 @@
 
 from locust import task
 
-from edfi_performance_test.api.client.school import SchoolClient
 from edfi_performance_test.tasks.volume.ed_fi_volume_test_base import EdFiVolumeTestBase
 
 
 class CourseOfferingVolumeTest(EdFiVolumeTestBase):
     @task
     def run_course_offering_scenarios(self):
-        high_school_id = SchoolClient.shared_high_school_id()
         self.run_scenario("localCourseTitle", "English Language Arts, Grade 2")
-        self.run_scenario(
-            "localCourseTitle",
-            "Algebra II",
-            schoolId=high_school_id,
-            localCourseCode="ALG-2",
-            localCourseTitle="Algebra 02 GBHS",
-            courseReference__courseCode="ALG-2",
-            courseReference__educationOrganizationId=high_school_id,
-            schoolReference__schoolId=high_school_id,
-        )

--- a/src/edfi-performance-test/edfi_performance_test/tasks/volume/section.py
+++ b/src/edfi-performance-test/edfi_performance_test/tasks/volume/section.py
@@ -5,8 +5,6 @@
 
 from locust import task
 
-from edfi_performance_test.api.client.school import SchoolClient
-from edfi_performance_test.factories.utils import RandomSuffixAttribute
 from edfi_performance_test.tasks.volume.ed_fi_volume_test_base import EdFiVolumeTestBase
 
 
@@ -14,10 +12,3 @@ class SectionVolumeTest(EdFiVolumeTestBase):
     @task
     def run_section_scenarios(self):
         self.run_scenario("availableCredits", 2)
-        self.run_scenario(
-            "availableCredits",
-            3,
-            schoolId=SchoolClient.shared_high_school_id(),
-            sectionIdentifier=RandomSuffixAttribute("ALG12017RM901"),
-            courseCode="ALG-2",
-        )

--- a/src/edfi-performance-test/edfi_performance_test/tasks/volume/student.py
+++ b/src/edfi-performance-test/edfi_performance_test/tasks/volume/student.py
@@ -33,7 +33,7 @@ class StudentSchoolAssociationVolumeTest(EdFiVolumeTestBase):
         school_id = SchoolClient.shared_high_school_id()
         graduation_plan_reference = None
         graduationSchoolYear = StudentSchoolAssociationVolumeTest.get_graduation_plan_school_year(self, school_id)
-        if(graduationSchoolYear is not None):
+        if graduationSchoolYear is not None:
             graduation_plan_reference = {
                 "educationOrganizationId": school_id,
                 "graduationPlanTypeDescriptor": build_descriptor("GraduationPlanType", "Recommended"),

--- a/src/edfi-performance-test/edfi_performance_test/tasks/volume/student.py
+++ b/src/edfi-performance-test/edfi_performance_test/tasks/volume/student.py
@@ -31,15 +31,15 @@ class StudentSchoolAssociationVolumeTest(EdFiVolumeTestBase):
     @task
     def run_association_scenarios(self):
         school_id = SchoolClient.shared_high_school_id()
-        graduation_plan_reference = {  # Prepopulated graduation plan
-            "educationOrganizationId": school_id,
-            "graduationPlanTypeDescriptor": build_descriptor(
-                "GraduationPlanType", "Recommended"
-            ),
-            "graduationSchoolYear": StudentSchoolAssociationVolumeTest.get_graduation_plan_school_year(
-                self, school_id
-            ),
-        }
+        graduation_plan_reference = None
+        graduationSchoolYear = StudentSchoolAssociationVolumeTest.get_graduation_plan_school_year(self, school_id)
+        if(graduationSchoolYear is not None):
+            graduation_plan_reference = {
+                "educationOrganizationId": school_id,
+                "graduationPlanTypeDescriptor": build_descriptor("GraduationPlanType", "Recommended"),
+                "graduationSchoolYear": graduationSchoolYear,
+            }
+
         self.run_scenario(
             "entryDate",
             RandomDateAttribute(),
@@ -51,6 +51,8 @@ class StudentSchoolAssociationVolumeTest(EdFiVolumeTestBase):
         self.run_scenario(
             "graduationPlanReference",
             graduation_plan_reference,
+            primarySchool=True,
+            enrollmentTypeDescriptor=build_descriptor("EnrollmentType", "Current"),
             schoolReference__schoolId=school_id,
             entryGradeLevelDescriptor=build_descriptor("GradeLevel", "Ninth Grade"),
             classOfSchoolYearTypeReference__schoolYear=2020,


### PR DESCRIPTION
Updated the GradingPeriod key to align with changes introduced in v5. Since the API permits over-posting, I extended the base resources to include additional fields for compatibility.

Descriptor URIs in DMS are currently case-sensitive. I adjusted the test cases to correct casing issues. A follow-up update to DMS will enable case-insensitive handling of descriptor URIs.